### PR TITLE
Maintain lightmode for menu change with the slate background

### DIFF
--- a/components/layout/header/Header1.js
+++ b/components/layout/header/Header1.js
@@ -9,14 +9,21 @@ export default function Header1({ scroll, isMobileMenu, handleMobileMenu, header
         const handleScroll = () => {
             const offset = window.scrollY;
             const menu = document.querySelector('.wsmainwp');
-    
+            const body = document.body;
+
             if (offset > 100) {
+                if (body.classList.contains('theme--dark')) {
+                    menu.classList.add('theme--dark');
+                }
                 menu.classList.add('menuOnceScrolled');
             } else {
+                if (body.classList.contains('theme--dark')) {
+                    menu.classList.remove('theme--dark');
+                }
                 menu.classList.remove('menuOnceScrolled');
             }
         };
-    
+
         window.addEventListener('scroll', handleScroll);
     
         return () => {

--- a/public/css/menu.css
+++ b/public/css/menu.css
@@ -87,6 +87,12 @@
 
 .menuOnceScrolled {
   border-radius: 3px;
+  background-color: rgba(255, 255, 255, 0.2);
+  backdrop-filter: blur(8px);
+}
+
+.theme--dark.menuOnceScrolled {
+  border-radius: 3px;
   background: linear-gradient(hsla(255, 15%, 9%, 1), hsla(255, 15%, 9%, 0.2));
   backdrop-filter: blur(8px);
 }


### PR DESCRIPTION
This is just a small change that maintains the light-mode colors for the menu background while also working with dark mode. This might be important if we want to allow a toggle at some point to switch back and forth between light-mode and dark mode, or, if we want to automatically render the site depending on your individual OS settings.