### PR TITLE
Add a border around blog post images

### DIFF
--- a/components/sections/MediumBlog.js
+++ b/components/sections/MediumBlog.js
@@ -100,9 +100,16 @@ export default function MediumBlog() {
                       <div className="blog-post-img mb-35">
                         <Link href={item.link}>
                           <img
-                            className="img-fluid r-16"
+                            className="img-fluid light-theme-img r-16"
                             src={item.image}
                             alt="blog-post-image"
+                            style={{ border: "2px solid #000" }}
+                          />
+                          <img
+                            className="img-fluid dark-theme-img r-16"
+                            src={item.image}
+                            alt="blog-post-image"
+                            style={{ border: '1px solid #fff' }}
                           />
                         </Link>
                       </div>


### PR DESCRIPTION
For dark-mode, it's 1px, for light-mode, it's 2px (because it was harder to see in light mode).

Examples:

<img width="965" alt="image" src="https://github.com/koinos/koinos-io-website/assets/23157604/14870d61-f4db-4ce3-bc34-2c2c0315e539">

light mode:

<img width="978" alt="image" src="https://github.com/koinos/koinos-io-website/assets/23157604/f721866b-a192-46bd-a9f6-d501bfa96298">
