### PR TITLE
Slate background fix other elements

### DIFF
--- a/components/sections/Team.js
+++ b/components/sections/Team.js
@@ -119,7 +119,7 @@ export default function Team() {
     <>
       <section
         id="team"
-        className="gr--whitesmoke pb-40 inner-page-hero team-section"
+        className="pb-40 inner-page-hero team-section"
       >
         <div className="container">
           {/* SECTION TITLE */}

--- a/public/css/purple-theme.css
+++ b/public/css/purple-theme.css
@@ -3783,8 +3783,8 @@ span.sm-info {
 .black-scroll .scroll .wsmenu > .wsmenu-list > li > ul.sub-menu,
 .black-scroll .scroll .wsmenu > .wsmenu-list > li > .wsmegamenu,
 .black-scroll .scroll .wsmenu > .wsmenu-list > li > .wsmegamenu.halfmenu {
-  background-color: #2c3142 !important;
-  border: solid 1px #2c3142 !important;
+  background-color: #1e2129 !important;
+  border: solid 1px #1e2129 !important;
   -webkit-box-shadow: 0 2px 3px rgba(1, 1, 1, 0.1);
   -moz-box-shadow: 0 2px 3px rgba(1, 1, 1, 0.1);
   box-shadow: 0 2px 3px rgba(1, 1, 1, 0.1);
@@ -11622,14 +11622,14 @@ body.theme--dark {
 }
 
 .theme--dark .x-border {
-  border-top: 1px solid #1d212c;
-  border-bottom: 1px solid #1d212c;
+  border-top: 1px solid #1e2129;
+  border-bottom: 1px solid #1e2129;
 }
 .theme--dark .top-border {
-  border-top: 1px solid #1d212c;
+  border-top: 1px solid #1e2129;
 }
 .theme--dark .bottom-border {
-  border-bottom: 1px solid #1d212c;
+  border-bottom: 1px solid #1e2129;
 }
 
 .theme--dark .bg--white-300,
@@ -11640,7 +11640,7 @@ body.theme--dark {
 .theme--dark .shape--white-400:after,
 .theme--dark .shape--white-300:after,
 .theme--dark .shape--white-200:after {
-  background-color: #1d212c;
+  background-color: #1e2129;
 }
 
 .theme--dark .bg--02,
@@ -11961,8 +11961,8 @@ body.theme--dark {
 .theme--dark .wsmenu > .wsmenu-list > li > ul.sub-menu,
 .theme--dark .wsmenu > .wsmenu-list > li > .wsmegamenu,
 .theme--dark .wsmenu > .wsmenu-list > li > .wsmegamenu.halfmenu {
-  background-color: #2c3142 !important;
-  border: solid 1px #2c3142 !important;
+  background-color: #1e2129 !important;
+  border: solid 1px #1e2129 !important;
   -webkit-box-shadow: 0 2px 3px rgba(1, 1, 1, 0.1);
   -moz-box-shadow: 0 2px 3px rgba(1, 1, 1, 0.1);
   box-shadow: 0 2px 3px rgba(1, 1, 1, 0.1);
@@ -11971,9 +11971,9 @@ body.theme--dark {
 .theme--dark .wsmenu > .wsmenu-list > li > ul.sub-menu:before,
 .theme--dark .wsmenu > .wsmenu-list > li.mg_link:hover > a:after,
 .theme--dark .wsmenu > .wsmenu-list > li > .wsmegamenu.halfmenu:before {
-  background-color: #2c3142;
-  border-left: solid 1px #2c3142;
-  border-top: solid 1px #2c3142;
+  background-color: #1e2129;
+  border-left: solid 1px #1e2129;
+  border-top: solid 1px #1e2129;
 }
 
 .theme--dark .wsmenu > .wsmenu-list > li > ul.sub-menu > li > a,
@@ -12288,7 +12288,7 @@ body.theme--dark {
 }
 
 .theme--dark .hero-6-wrapper {
-  background-image: linear-gradient(90deg, #1d212c, #1d212c);
+  background-image: linear-gradient(90deg, #1e2129, #1e2129);
 }
 
 .theme--dark #hero-8-form {
@@ -12331,7 +12331,7 @@ body.theme--dark {
 }
 
 .theme--dark #hero-20:after {
-  background-image: linear-gradient(180deg, #1d212c, #232734);
+  background-image: linear-gradient(180deg, #1e2129, #232734);
 }
 
 .theme--dark #hero-21 .hero-overlay {
@@ -12394,11 +12394,11 @@ body.theme--dark {
 /*------------------------------------------*/
 
 .theme--dark #reviews-2 .review-2.bg--white-100 {
-  background-color: #1d212c !important;
+  background-color: #1e2129 !important;
 }
 
 .theme--dark .owl-theme .owl-dots .owl-dot span {
-  background: #1d212c;
+  background: #1e2129;
 }
 
 .theme--dark .owl-theme .owl-dots .owl-dot.active span {
@@ -12430,8 +12430,8 @@ body.theme--dark {
 /*------------------------------------------*/
 
 .theme--dark .rbox-1 .star-rating {
-  background-color: #1d212c !important;
-  border: 1px solid #1d212c;
+  background-color: #1e2129 !important;
+  border: 1px solid #1e2129;
   -webkit-box-shadow: 0 4px 12px 0 rgba(0, 0, 0, 0.13);
   -moz-box-shadow: 0 4px 12px 0 rgba(0, 0, 0, 0.13);
   box-shadow: 0 4px 12px 0 rgba(0, 0, 0, 0.13);
@@ -12468,8 +12468,8 @@ body.theme--dark {
 /*------------------------------------------*/
 
 .theme--dark .integrations-1-wrapper .in_tool {
-  background-color: #1d212c;
-  border: 1px solid #1d212c;
+  background-color: #1e2129;
+  border: 1px solid #1e2129;
 }
 
 /*------------------------------------------*/
@@ -12573,7 +12573,7 @@ body.theme--dark {
 /*------------------------------------------*/
 
 .theme--dark .txt-code {
-  background-color: #1d212c;
+  background-color: #1e2129;
 }
 
 .theme--dark .txt-code kbd {
@@ -12740,7 +12740,7 @@ body.theme--dark {
 
 .theme--dark #login .register-page-wrapper:after,
 .theme--dark #signup .register-page-wrapper:after {
-  background-color: #1d212c;
+  background-color: #1e2129;
 }
 
 .theme--dark .form-data span a,
@@ -12761,8 +12761,8 @@ body.theme--dark {
 }
 
 .theme--dark .reset-page-wrapper form {
-  background: #1d212c;
-  border: 1px solid #1d212c;
+  background: #1e2129;
+  border: 1px solid #1e2129;
 }
 
 .theme--dark .register-page-form .form-control::-moz-placeholder {


### PR DESCRIPTION
This just switches to #1e2129 for all of the background elements. It also fixes the css on the team section so it doesn't look out of place.
