### PR TITLE
Remove raffles because they don't exist

### DIFF
--- a/components/sections/Integrations1_1.js
+++ b/components/sections/Integrations1_1.js
@@ -53,12 +53,6 @@ export default function Integrations1_1() {
       url: "https://burnkoin.com/",
     },
     {
-      name: "Koinos Raffles",
-      description: "Gambling",
-      icon: "/images/dapps/koinos-raffles.png",
-      url: "https://koinosraffles.io/",
-    },
-    {
       name: "Koinos Blocks",
       description: "Block Explorer",
       icon: "/images/dapps/koinosblocks.png",


### PR DESCRIPTION
People keep bringing this up in telegram so just going ahead and doing it. Apparently their site doesn't exist anymore, nor their discord, they are gone.
