### PR TITLE
#84 hide roadmap icons on mobile

### DIFF
--- a/components/sections/Roadmap.js
+++ b/components/sections/Roadmap.js
@@ -138,8 +138,8 @@ export default function Roadmap() {
                                         <h5 className="s-22 w-700">{item.title}</h5>
                                         {item.description.map((desc, idx) => (
                                             <div key={idx} className="d-flex align-items-center justify-content-end gap-3">
-                                               <div>{desc.text}</div>
-                                               <div className="d-flex justify-content-center"  style={{ width: '32px', minWidth: '32px'}}><i className={`m-2 ${desc.icon}`}></i></div>
+                                               <div>{desc.text}</div> 
+                                               <div className="d-flex justify-content-center d-none d-md-flex"  style={{ width: '42px', minWidth: '42px'}}><i className={`m-2 ${desc.icon}`}></i> </div>
                                             </div>
                                         ))}
                                     </>
@@ -162,7 +162,7 @@ export default function Roadmap() {
                                         <h5 className="s-22 w-700">{item.title}</h5>
                                         {item.description.map((desc, idx) => (
                                             <div key={idx} className="d-flex align-items-center justify-content-start gap-3">
-                                                <div className="d-flex justify-content-center"  style={{ width: '32px', minWidth: '32px'}}><i className={`m-2 ${desc.icon}`}></i></div>
+                                                <div className="d-flex justify-content-center d-none d-md-flex"  style={{ width: '42px', minWidth: '42px'}}><i className={`m-2 ${desc.icon}`}></i></div>
                                                 <div>{desc.text}</div>
                                             </div>
                                         ))}
@@ -190,7 +190,8 @@ export default function Roadmap() {
                                         {item.description.map((desc, idx) => (
                                             <div key={idx} className="d-flex align-items-center justify-content-end gap-3">
                                                 <div>{desc.text}</div>
-                                                <div className="d-flex justify-content-center"  style={{ width: '32px', minWidth: '32px'}}><i className={`m-2 ${desc.icon}`}></i></div>
+                                                <div className="d-flex justify-content-center d-none d-md-flex"  style={{ width: '42px', minWidth: '42px'}}><i className={`m-2 ${desc.icon}`}></i></div>
+                                                 
                                             </div>
                                         ))}
                                     </>
@@ -213,7 +214,7 @@ export default function Roadmap() {
                                         <h5 className="s-22 w-700">{item.title}</h5>
                                         {item.description.map((desc, idx) => (
                                             <div key={idx} className="d-flex align-items-center justify-content-start gap-3">
-                                                <div className="d-flex justify-content-center"  style={{ width: '32px', minWidth: '32px'}}><i className={`m-2 ${desc.icon}`}></i></div><div>{desc.text}</div>
+                                                <div className="d-flex justify-content-center d-none d-md-flex"  style={{ width: '42px', minWidth: '42px'}}><i className={`m-2 ${desc.icon}`}></i></div><div>{desc.text}</div>
                                             </div>
                                         ))}
                                     </>


### PR DESCRIPTION
Resolves #84 

## Brief description
Added css class to dynamically hide the icons on the roadmap list on mobile. 

## Checklist

- [x] I have built this pull request locally
- [ ] I have ran the unit tests locally
- [x] I have manually tested this pull request
- [x] I have reviewed my pull request
- [ ] I have added any relevant tests

## Demonstration
![image](https://github.com/koinos/koinos-io-website/assets/70003/71f09350-8e51-47bd-8a64-08b44de8219f)

