### PR TITLE
Update the chainge link to the v2 dapp buying KOIN

### DIFF
--- a/components/slider/BrandSlider1.js
+++ b/components/slider/BrandSlider1.js
@@ -62,7 +62,7 @@ export default function BrandSlider1() {
             name: 'chainge',
             imageLight: '/images/exchanges/chainge.png',
             imageDark: '/images/exchanges/chainge-white.png',
-            url: 'https://www.chainge.finance/info/currencies/KOIN'
+            url: 'https://dapp.chainge.finance/?fromChain=ETH&toChain=KOIN&fromToken=USDT&toToken=KOIN'
         },
         {
             name: 'lcx',


### PR DESCRIPTION
## Brief description

Fixes the Chainge link to point to the v2 dapp and pre-fill KOIN as the destination token.

## Checklist

- [X] I have built this pull request locally
- [ ] I have ran the unit tests locally
- [X] I have manually tested this pull request
- [X] I have reviewed my pull request
- [ ] I have added any relevant tests

## Demonstration
<!-- If applicable, attach screenshot or terminal output of working code -->
